### PR TITLE
Change rocketinsights to project-hamilton

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Currently tgenv supports the following OSes
 Install via [Homebrew](https://docs.brew.sh/Installation)
 
   ```console
-  $ brew tap rocketinsights/tgenv
+  $ brew tap project-hamilton/tgenv
   $ brew install tgenv
   ```
 
-Note: The Hombrew tap is maintained [here: rocketinsights/homebrew-tgenv](https://github.com/rocketinsights/homebrew-tgenv)
+Note: The Hombrew tap is maintained [here: project-hamilton/homebrew-tgenv](https://github.com/project-hamilton/homebrew-tgenv)
 
 
 ### Manual
@@ -25,7 +25,7 @@ Note: The Hombrew tap is maintained [here: rocketinsights/homebrew-tgenv](https:
 1. Check out tgenv into any path (here is `${HOME}/.tgenv`)
 
   ```console
-  $ git clone https://github.com/rocketinsights/tgenv.git ~/.tgenv
+  $ git clone https://github.com/project-hamilton/tgenv.git ~/.tgenv
   ```
 
 2. Add `~/.tgenv/bin` to your `$PATH` any way you like
@@ -217,7 +217,7 @@ Uninstalling via Homebrew
 
 ```sh
 $ brew uninstall tgenv           # Uninstalls tgenv and associated Terragrunt release(s)
-$ brew untap rocketinsights/tgenv     # Removes the tap
+$ brew untap project-hamilton/tgenv     # Removes the tap
 ```
 
 ### Manual
@@ -228,6 +228,6 @@ $ rm -rf /some/path/to/tgenv
 
 
 ## LICENSE
-- [tgenv](https://github.com/rocketinsights/tgenv/blob/master/LICENSE) : Our version of tgenv
+- [tgenv](https://github.com/project-hamilton/tgenv/blob/master/LICENSE) : Our version of tgenv
 - [tgenv source](https://github.com/sigsegv13/tgenv/blob/master/LICENSE) : Origin of our version of tgenv
 - [tfenv](https://github.com/tfutils/tfenv/blob/master/LICENSE) : tgenv is based on tfenv's source code


### PR DESCRIPTION
This repo was forked from rocketinsights/tgenv so we needed to update the README.

Addresses https://github.com/project-hamilton/devops-board/issues/83
